### PR TITLE
Add wind charge to the reach/A blacklist to prevent false flags

### DIFF
--- a/scripts/data/config.js
+++ b/scripts/data/config.js
@@ -502,7 +502,8 @@ export default
 				"minecraft:enderman",
 				"minecraft:fireball",
 				"minecraft:ender_dragon",
-				"minecraft:ghast"
+				"minecraft:ghast",
+				"minecraft:wind_charge_projectile"
 			],
 			"punishment": "none",
 			"minVlbeforePunishment": 0


### PR DESCRIPTION
When hitting a wind charge it can false flag as Reach/A.

Also, when hitting a entity when using a wind charge on the entity can also false flag, but very less. This doesn't fix that issue though.